### PR TITLE
Local build script improvements

### DIFF
--- a/scripts/local/generate.sh
+++ b/scripts/local/generate.sh
@@ -2,12 +2,23 @@
 
 # Set variables
 DOCUMENTATION_VERSION="latest"
-BUILD_DIR="build/${DOCUMENTATION_VERSION}"
 SOURCE_PATH="src"
 IMAGES_PATH="${SOURCE_PATH}/images"
 ROOT_ADOC_PATH="${SOURCE_PATH}/Reference"
 ROOT_ADOC_FILENAME="default.adoc"
 ROOT_ADOC="${ROOT_ADOC_PATH}/${ROOT_ADOC_FILENAME}"
+
+# Collect user args
+while getopts V: option
+do
+case "${option}"
+in
+V) DOCUMENTATION_VERSION=${OPTARG};;
+esac
+done
+
+# Set varibles
+BUILD_DIR="build/${DOCUMENTATION_VERSION}"
 
 # Copy dependencies
 mkdir -p "${BUILD_DIR}"
@@ -15,4 +26,9 @@ cp -R "${ROOT_ADOC_PATH}/tocbot-3.0.2" "$BUILD_DIR/"
 cp -R "${IMAGES_PATH}" "$BUILD_DIR/"
 
 # Create the HTML
-asciidoctor -d book "$ROOT_ADOC" -D "$BUILD_DIR" -a toc=left -a docinfo=shared
+echo "Building asciidoctor HTML to $BUILD_DIR/index.html..."
+asciidoctor -d book "$ROOT_ADOC" -D "$BUILD_DIR" -a toc=left -a docinfo=shared -o "index.html"
+
+# Create the PDF
+echo "Building asciidoctor PDF to $BUILD_DIR/$DOCUMENTATION_VERSION.pdf..."
+asciidoctor-pdf -d book "$ROOT_ADOC" -D "$BUILD_DIR" -o "$DOCUMENTATION_VERSION.pdf" -a imagesdir="../images"

--- a/src/Reference/default.adoc
+++ b/src/Reference/default.adoc
@@ -1,5 +1,5 @@
 [[framework-core]]
-= Core Technologies
+= Framework Reference Documentation
 :toc: left
 :numbered:
 :toclevels: 4


### PR DESCRIPTION
Can now pass -V to specify a VERSION representing the framework version. Asciidoc outputs now build to 'build/VERSION' and now produce both .html and .pdf files