### PR TITLE
Replace and Update Executor Documentation Updates

### DIFF
--- a/src/Reference/pages/command-dsl/pages/actions/pages/replace/default.adoc
+++ b/src/Reference/pages/command-dsl/pages/actions/pages/replace/default.adoc
@@ -103,7 +103,9 @@ NOTE: The important thing to note in this scenario, is that like all other scena
 
 where `PATH_TO_PARAM` is path which points to another param, relative to the location of `single_element`.
 
-As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the `rawPayload`. The value to be set will be the same as the state of the object identified by `PATH_TO_PARAM`. This scenario can be used to copy a param's state from one param to another.
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the `rawPayload`. The value to be set will be the same as the state of the object identified by `PATH_TO_PARAM`.
+
+TIP: This scenario can be used to copy a param's state from one param to another.
 
 ---
 

--- a/src/Reference/pages/command-dsl/pages/actions/pages/replace/default.adoc
+++ b/src/Reference/pages/command-dsl/pages/actions/pages/replace/default.adoc
@@ -13,7 +13,6 @@ The following class will be used in the __replace_ scenarios to follow.
 public class SampleEntity {
 
     private String single_element;
-
     private List<String> collection;
 }
 ----
@@ -37,9 +36,12 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 [source,json]
 ----
 {
-    "single_element": "hello"
+    "single_element": "hello",
+    "collection": ["empty_value_1"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the `rawPayload`. The value for the field of `collection` is unaffected and retains it's previous value.
 
 ---
 
@@ -51,9 +53,12 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 [source,json]
 ----
 {
+    "single_element": "empty_value",
     "collection": [ "hello" ]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/collection/0`, only the collection element having index `0` for the field `collection` is subject to be replaced with the `rawPayload`. The value for the field of `single_element` is unaffected and retains it's previous value.
 
 ---
 
@@ -65,9 +70,12 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 [source,json]
 ----
 {
+    "single_element": "empty_value",
     "collection": [ "1", "2" ]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/collection`, only the field `collection` is subject to be replaced with the `rawPayload`. The value for the field of `single_element` is unaffected and retains it's previous value.
 
 ---
 
@@ -83,6 +91,8 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 }
 ----
 
+As the path in this scenario is pointing to `sample_entity:1`, both fields are subject to be replaced with the `rawPayload`. In this scenario, only `single_element` has been provided which results in `collection` having a `null` value.
+
 NOTE: The important thing to note in this scenario, is that like all other scenarios the existing state is replaced. This means that if _collection_ of the entity located at _sample_entity:1_ had an existing value, it will be set to  `null` since the _rawPayload_ parameter did not explicitely set it.
 
 ---
@@ -92,6 +102,8 @@ NOTE: The important thing to note in this scenario, is that like all other scena
 `@Config(url = "sample_entity:1/single_element/_replace?rawPayload=<!json(PATH_TO_PARAM)!>)`
 
 where `PATH_TO_PARAM` is path which points to another param, relative to the location of `single_element`.
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the `rawPayload`. The value to be set will be the same as the state of the object identified by `PATH_TO_PARAM`. This scenario can be used to copy a param's state from one param to another.
 
 ---
 
@@ -106,9 +118,12 @@ where `PATH_TO_PARAM` is path which points to another param, relative to the loc
 [source,json]
 ----
 {
-    "single_element": "hello"
+    "single_element": "hello",
+    "collection": ["empty_value_1"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the HTTP post data. The value for the field of `collection` is unaffected and retains it's previous value.
 
 ---
 
@@ -122,6 +137,8 @@ where `PATH_TO_PARAM` is path which points to another param, relative to the loc
 [source,json]
 ----
 {
-
+    "collection": ["empty_value_1"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be replaced with the HTTP post data. In this case the post data is `null` so the resulting value for `single_element` will then be `null`. The value for the field of `collection` is unaffected and retains it's previous value.

--- a/src/Reference/pages/command-dsl/pages/actions/pages/update/default.adoc
+++ b/src/Reference/pages/command-dsl/pages/actions/pages/update/default.adoc
@@ -42,6 +42,8 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 }
 ----
 
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be updated with the value of `rawPayload`. The value for the field of `collection` is unaffected and retains it's previous value.
+
 ---
 
 [discrete]
@@ -52,25 +54,46 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 [source,json]
 ----
 {
-    "single_element": "hello",
+    "single_element": "empty_value",
     "collection": ["hello"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/collection/0`, only the collection element at index `0` for the field `collection` is subject to be updated with the value of `rawPayload`. The value for the field of `single_element` is unaffected and retains it's previous value.
 
 ---
 
 [discrete]
 === Updating a collection state
-`@Config(url = "sample_entity:1/collection/_update?rawPayload='[\"1\", \"2\"]'")`
+`@Config(url = "sample_entity:1/collection/_update?rawPayload='\"new_value\"'")`
 
 .Resulting State of _sample_entity:1_
 [source,json]
 ----
 {
     "single_element": "empty_value",
-    "collection": ["1", "2"]
+    "collection": ["empty_value_1", "new_value"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/collection`, only the field `collection` is subject to be updated with the value of `rawPayload`. Performing an __update_ call on a collection essentially performs an *add* operation. The value for the field of `single_element` is unaffected and retains it's previous value.
+
+TIP: If needing to replace elements within the collection as a whole, consider using <<command-dsl-actions-replace>>.
+
+It is also permissible to pass an array as a payload. 
+
+`@Config(url = "sample_entity:1/collection/_update?rawPayload='[\"new_value_1\", \"new_value_2\"]'")`
+
+.Resulting State of _sample_entity:1_
+[source,json]
+----
+{
+    "single_element": "empty_value",
+    "collection": ["empty_value_1", "new_value_1", "new_value_2"]
+}
+----
+
+In this scenario, *all of the array elements* within `rawPayload` would be added to the collection.
 
 ---
 
@@ -87,6 +110,10 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 }
 ----
 
+As the path in this scenario is pointing to `sample_entity:1`, both fields are subject to be updated with the value of `rawPayload`. Performing an __update_ call in this call preserves any previously existing state for fields not specified in the `rawPayload`. Consequently, the value for the field of `single_element` is updated, while `collection` is unaffected and retains it's previous value.
+
+TIP: Nested domain models can become quite large! Use __update_ when needing to target specific values within a domain entity.
+
 ---
 
 [discrete]
@@ -94,6 +121,10 @@ The following scenarios will also assume that the param at _sample_entity:1_ has
 `@Config(url = "sample_entity:1/single_element/_update?rawPayload=<!json(PATH_TO_PARAM)!>)`
 
 where `PATH_TO_PARAM` is path which points to another param, relative to the location of `single_element`.
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be updated with the value of `rawPayload`. The value to be set will be the same as the state of the object identified by `PATH_TO_PARAM`.
+
+TIP: This scenario can be used to copy a param's state from one param to another.
 
 ---
 
@@ -112,3 +143,5 @@ where `PATH_TO_PARAM` is path which points to another param, relative to the loc
     "collection": ["empty_value_1"]
 }
 ----
+
+As the path in this scenario is pointing to `sample_entity:1/single_element`, only the field `single_element` is subject to be updated with the HTTP post data. The value for the field of `collection` is unaffected and retains it's previous value.

--- a/src/Reference/pages/command-dsl/pages/actions/pages/update/default.adoc
+++ b/src/Reference/pages/command-dsl/pages/actions/pages/update/default.adoc
@@ -13,7 +13,6 @@ The following class will be used in the __update_ scenarios to follow.
 public class SampleEntity {
 
     private String single_element;
-
     private List<String> collection;
 }
 ----


### PR DESCRIPTION
# Overview of Changes
* Fixed some errors in _replace documentation where the wrong "resulting state" was given.
* Added a description for each of the `_replace` and `_update` scenarios for more comprehensive explanations.
* Added new _update scenarios for updating a collection with a `rawPayload` of a JSON object or JSON array (*add* and *addAll* functionalities)