### PR TITLE
NIMBUS-247: Cleanup build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ gradle-app.setting
 .DS_Store
 
 # End of https://www.gitignore.io/api/gradle
+
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ This repository holds the documentation source code for the [Nimbus Framework](h
 # Development
 The documentation is maintained using Asciidoctor.
 
+## Setup
+1. Install [Asciidoctor](https://asciidoctor.org/)
+2. Install [coderay](https://github.com/rubychan/coderay) (for syntax highlighting)
+
 ## Building the documentation
 ```sh
 npm run build
 ```
-NOTE: Asciidoctor and coderay should be installed.
 
 **Arguments**  
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@
 # About
 This repository holds the documentation source code for the [Nimbus Framework](https://github.com/openanthem/nimbus-core).
 
+# Development
+The documentation is maintained using Asciidoctor.
+
+## Building the documentation
+```sh
+npm run build
+```
+NOTE: Asciidoctor and coderay should be installed.
+
+**Arguments**  
+
+| name | description |
+|---|---|
+| quiet | whether or not to execute the build without user interaction. default: false |
+| version | the version of the documentation. default: package.json[version] + package.json[release-type] |
+
+## Publishing the documentation
+```sh
+npm run publish
+```
+
+**Arguments**  
+
+| name | description |
+|---|---|
+| version | the version of the documentation. default: package.json[version] + package.json[release-type] |
+
 # Useful Links
 The published documentation is hosted on GitHub (`gh-pages`) and can be found here: https://openanthem.github.io/nimbus-docs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -56,6 +62,18 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
     "email-addresses": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
@@ -66,6 +84,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
     "filename-reserved-regex": {
@@ -171,6 +195,12 @@
         "strip-url-auth": "^1.0.0"
       }
     },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -199,6 +229,12 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -222,6 +258,33 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -283,11 +346,31 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.3.x",
+        "winston": "2.1.x"
+      }
     },
     "query-string": {
       "version": "4.3.4",
@@ -297,6 +380,15 @@
       "requires": {
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
       }
     },
     "rechoir": {
@@ -316,6 +408,12 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
@@ -345,6 +443,12 @@
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -381,6 +485,63 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "deep-equal": "~0.2.1",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "1.0.x",
+        "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
+      }
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dev": true,
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,12 @@
         "glob": "^7.1.3"
       }
     },
+    "semver": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+      "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+      "dev": true
+    },
     "shelljs": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,392 @@
+{
+  "name": "nimbus-docs",
+  "version": "1.3.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "email-addresses": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "filenamify-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
+      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+      "dev": true,
+      "requires": {
+        "filenamify": "^1.0.0",
+        "humanize-url": "^1.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gh-pages": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.0.1.tgz",
+      "integrity": "sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify-url": "^1.0.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^6.1.0",
+        "graceful-fs": "^4.1.11",
+        "rimraf": "^2.6.2"
+      }
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
+    },
+    "humanize-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+      "dev": true,
+      "requires": {
+        "normalize-url": "^1.0.0",
+        "strip-url-auth": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "strip-url-auth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
+      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+      "dev": true
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "url": "https://github.com/openanthem/nimbus-docs.git"
   },
   "scripts": {
+    "build": "node scripts/build.js",
     "publish": "node scripts/publish-ghpages.js"
   },
   "pre-commit": [],
   "dependencies": {},
   "devDependencies": {
     "gh-pages": "^2.0.1",
+    "prompt": "^1.0.0",
     "shelljs": "^0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "gh-pages": "^2.0.1",
     "prompt": "^1.0.0",
+    "semver": "^6.2.0",
     "shelljs": "^0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nimbus-docs",
+  "version": "1.3.1",
+  "release-type": "BUILD-SNAPSHOT",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openanthem/nimbus-docs.git"
+  },
+  "scripts": {
+    "publish": "node scripts/publish-ghpages.js"
+  },
+  "pre-commit": [],
+  "dependencies": {},
+  "devDependencies": {
+    "gh-pages": "^2.0.1",
+    "shelljs": "^0.8.3"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,10 @@ var args = tools.getArgs();
 var version = args['version'] ? args['version'] : VERSION;
 var quiet = args['quiet'] ? true : false;
 
+if (tools.isValidVersion(version)) {
+    throw new Error(`The version '${version}' is not a valid version.`);
+}
+
 // quiet mode
 if (quiet) {
     build(version);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,47 @@
+const shell = require('shelljs');
+const prompt = require('prompt');
+const tools = require('./tools');
+
+const NPM_VERSION = process.env.npm_package_version;
+const RELEASE_TYPE = process.env.npm_package_release_type;
+const VERSION = `${NPM_VERSION}.${RELEASE_TYPE}`;
+
+var args = tools.getArgs();
+var version = args['version'] ? args['version'] : VERSION;
+var quiet = args['quiet'] ? true : false;
+
+// quiet mode
+if (quiet) {
+    build(version);
+
+} else {
+    
+    var promptProperties = {};
+    
+    // Prompt for new version
+    if (!args['version']) {
+        promptProperties['newVersion'] = {
+            description: `Enter the version`,
+            default: `${VERSION}`,
+            required: true
+        };
+    }
+
+    // collect the user input
+    prompt.start();
+    prompt.get({ properties: promptProperties }, function (err, result) {
+        if (!result) {
+            return;
+        }
+
+        if (result.newVersion) {
+            version = result.newVersion;
+        }
+
+        build(version);
+    });
+}
+
+function build(version) {
+    shell.exec(`./scripts/generate.sh -V ${version}`);
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -20,7 +20,7 @@ do
 done
 
 # Set varibles
-BUILD_DIR="build/${DOCUMENTATION_VERSION}"
+BUILD_DIR="dist/${DOCUMENTATION_VERSION}"
 
 # Add an HTML Header
 # TODO Handle this in AsciiDoctor.

--- a/scripts/publish-ghpages.js
+++ b/scripts/publish-ghpages.js
@@ -9,8 +9,7 @@ const VERSION = `${NPM_VERSION}.${RELEASE_TYPE}`;
 var args = tools.getArgs();
 
 var version = args['version'] ? args['version'] : VERSION;
-var releaseType = version.substr(version.lastIndexOf('.') + 1);
-var shouldPublish = 'BUILD-SNAPSHOT' !== releaseType;
+var releaseType = tools.getReleaseType(version);
 
 var options = {
     src: '**/*',
@@ -20,7 +19,11 @@ var options = {
     message: `${version} updates`,
 };
 
-if (!shouldPublish) {
+if (!tools.isValidVersion(version)) {
+    throw new Error(`The version '${version}' is not a valid version.`);
+}
+
+if (!tools.isRelease(version)) {
     console.log(`${version} has a release type of '${releaseType}'. Skipping publish step.`);
     return;
 }

--- a/scripts/publish-ghpages.js
+++ b/scripts/publish-ghpages.js
@@ -1,31 +1,43 @@
-var shell = require('shelljs');
+const ghpages = require('gh-pages');
+const fs = require("fs");
+const tools = require('./tools');
 
 const NPM_VERSION = process.env.npm_package_version;
 const RELEASE_TYPE = process.env.npm_package_release_type;
 const VERSION = `${NPM_VERSION}.${RELEASE_TYPE}`;
 
-console.log('Generating HTML content from asciidoc...');
-shell.exec(`./scripts/generate.sh -V ${VERSION}`);
+var args = tools.getArgs();
 
-var ghpages = require('gh-pages');
+var version = args['version'] ? args['version'] : VERSION;
+var releaseType = version.substr(version.lastIndexOf('.') + 1);
+var shouldPublish = 'BUILD-SNAPSHOT' !== releaseType;
 
 var options = {
     src: '**/*',
     branch: 'gh-pages',
-    dest: `${VERSION}`,
-    message: `${VERSION} updates`,
+    dest: `${version}`,
+    remote: 'origin',
+    message: `${version} updates`,
 };
 
-var isRelease = 'BUILD-SNAPSHOT' !== RELEASE_TYPE;
-var shouldDeploy = true;
-
-if (isRelease) {
-    options.tag = `v${VERSION}`;
+if (!shouldPublish) {
+    console.log(`${version} has a release type of '${releaseType}'. Skipping publish step.`);
+    return;
 }
 
-if (shouldDeploy) {
-    console.log('Publishing HTML content to gh-pages...');
-    ghpages.publish(`dist/${VERSION}`, options, function(err) {
-        throw err;
+var dirToPublish = `dist/${version}`;
+if (!fs.existsSync(dirToPublish)) {
+    throw new Error(`Failed to publish content from '${dirToPublish}' because the directory does not exist. Did you run 'npm build' yet?`);
+}
+publish(dirToPublish, options);
+
+function publish(dirToPublish, options) {
+    var outLocation = `${options.remote}/${options.branch}`;
+    console.log(`Publishing HTML content to ${outLocation}...`);
+    ghpages.publish(dirToPublish, options, function(err) {
+        if (err) {
+            // handle error if necessary
+        }
+        console.log(`Pushed published content to ${outLocation}.`);
     });
 }

--- a/scripts/publish-ghpages.js
+++ b/scripts/publish-ghpages.js
@@ -1,0 +1,7 @@
+var shell = require('shelljs');
+
+const NPM_VERSION = process.env.npm_package_version;
+const RELEASE_TYPE = process.env.npm_package_release_type;
+const VERSION = `${NPM_VERSION}.${RELEASE_TYPE}`;
+
+shell.exec(`./scripts/generate.sh -V ${VERSION}`);

--- a/scripts/publish-ghpages.js
+++ b/scripts/publish-ghpages.js
@@ -4,4 +4,28 @@ const NPM_VERSION = process.env.npm_package_version;
 const RELEASE_TYPE = process.env.npm_package_release_type;
 const VERSION = `${NPM_VERSION}.${RELEASE_TYPE}`;
 
+console.log('Generating HTML content from asciidoc...');
 shell.exec(`./scripts/generate.sh -V ${VERSION}`);
+
+var ghpages = require('gh-pages');
+
+var options = {
+    src: '**/*',
+    branch: 'gh-pages',
+    dest: `${VERSION}`,
+    message: `${VERSION} updates`,
+};
+
+var isRelease = 'BUILD-SNAPSHOT' !== RELEASE_TYPE;
+var shouldDeploy = true;
+
+if (isRelease) {
+    options.tag = `v${VERSION}`;
+}
+
+if (shouldDeploy) {
+    console.log('Publishing HTML content to gh-pages...');
+    ghpages.publish(`dist/${VERSION}`, options, function(err) {
+        throw err;
+    });
+}

--- a/scripts/tools.js
+++ b/scripts/tools.js
@@ -1,0 +1,16 @@
+module.exports = {
+    getArgs: function() {
+        var args = {};
+        process.argv.slice(2).forEach(function (arg) {
+            var key = arg;
+            var value = true;
+            var splits = arg.split('=');
+            if (splits.length > 1) {
+                key = splits[0];
+                value = arg.slice(arg.indexOf('=') + 1);
+            }
+            args[key] = value;
+        });
+        return args;
+    }
+}

--- a/scripts/tools.js
+++ b/scripts/tools.js
@@ -1,3 +1,5 @@
+const semver = require('semver');
+
 module.exports = {
     getArgs: function() {
         var args = {};
@@ -12,5 +14,35 @@ module.exports = {
             args[key] = value;
         });
         return args;
+    },
+    getReleaseType: function(version) {
+        if (!this.isValidVersion(version)) {
+            return undefined;
+        }
+        return version.substr(version.lastIndexOf('.') + 1);
+    },
+    isRelease: function(version) {
+        if (!this.isValidVersion(version)) {
+            return false;
+        }
+        let releaseType = this.getReleaseType(version);
+        return 'BUILD-SNAPSHOT' !== releaseType;
+    },
+    isValidVersion: function (version) {
+        if (!version) {
+            return false;
+        }
+        let parts = version.split('.');
+        if (parts.length === 3) {
+            return semver.valid(version);
+        } else if (parts.length === 4) {
+            let releaseType = parts.pop();
+            let semverVersion = parts.join('.');
+            if (!semver.valid(semverVersion)) {
+                return false;
+            }
+            return releaseType.match(/^BUILD-SNAPSHOT|RELEASE|M\d+/g);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Implements [NIMBUS-247](https://anthemopensource.atlassian.net/browse/NIMBUS-247).

Cleans up the the existing build scripts. Converts the project to be managed by node for ci/cd support

# Changes
* `generate.sh` has been moved from `scripts/local/generate.sh` to `scripts/generate.sh`
  * output directory changed from `build/` to `dist/`
* building the documentation can now be performed using `npm run build`
* publishing the documentation can now be performed using `npm run publish`
* added package.json for node management.

# Additional notes
This change should assist in automating the build/publish process in Bamboo.